### PR TITLE
proposed implementation ready to go

### DIFF
--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -18,18 +18,15 @@ if 'BANANA_URL' in os.environ:
 # ___________________________________
 
 
-def run_main(api_key, model_key, model_parameters):
-    task_id = call_start_api(api_key, model_key, model_parameters)
+def run_main(api_key, model_key, model_parameters, strategy):
+    task_id = call_start_api(api_key, model_key, model_parameters, strategy)
     # Just hardcode intervals
     while True:
         dict_out = call_check_api(api_key, task_id)
         if dict_out['data']['taskStatus'] == "Done":
-            if "output" in dict_out['data']['taskOut']:
-                return dict_out['data']['taskOut']["output"]
-            else:
-                return dict_out['data']['taskOut']
-def start_main(api_key, model_key, model_parameters):
-    task_id = call_start_api(api_key, model_key, model_parameters)
+            return dict_out['data']['taskOut']
+def start_main(api_key, model_key, model_parameters, strategy):
+    task_id = call_start_api(api_key, model_key, model_parameters, strategy)
     return task_id
 def check_main(api_key, task_id):
     dict_out = call_check_api(api_key, task_id)
@@ -40,9 +37,9 @@ def check_main(api_key, task_id):
 # ________________________
 
 # Takes in start params, returns task ID
-def call_start_api(api_key, model_key, model_parameters):
+def call_start_api(api_key, model_key, model_parameters, strategy):
     global endpoint
-    route_start = "api/task/start/v1/"
+    route_start = "api/task/start/v2/"
     url_start = endpoint + route_start
 
     payload = {
@@ -51,7 +48,8 @@ def call_start_api(api_key, model_key, model_parameters):
         "data": {
             "apiKey" : api_key,
             "modelKey" : model_key,
-            "modelParameters" : model_parameters
+            "modelParameters" : model_parameters,
+            "strategy": strategy,
         }
     }
     response = requests.post(url_start, json=payload)

--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -44,7 +44,7 @@ def call_start_api(api_key, model_key, model_parameters, strategy):
 
     payload = {
         "id": str(uuid4()),
-        "created": int(time.time()),
+        "created": time.time(),
         "data": {
             "apiKey" : api_key,
             "modelKey" : model_key,
@@ -74,7 +74,7 @@ def call_start_api(api_key, model_key, model_parameters, strategy):
 # Takes in task ID, returns reformatted dict_out with Status and Output
 def call_check_api(api_key, task_id):
     global endpoint
-    route_check = "api/task/check/v1/"
+    route_check = "api/task/check/v2/"
     url_check = endpoint + route_check
     # Poll server for completed task
 

--- a/banana_dev/package.py
+++ b/banana_dev/package.py
@@ -3,19 +3,21 @@ import asyncio
 import sys
 
 # Generics
-def run(api_key, model_key, model_parameters):
+def run(api_key, model_key, model_parameters, strategy = {}):
     out = run_main(
         api_key = api_key, 
         model_key = model_key, 
-        model_parameters = model_parameters
+        model_parameters = model_parameters,
+        strategy = strategy,
     )
     return out
 
-def start(api_key, model_key, model_parameters):
+def start(api_key, model_key, model_parameters, strategy = {}):
     out = start_main(
         api_key = api_key, 
         model_key = model_key, 
-        model_parameters = model_parameters
+        model_parameters = model_parameters,
+        strategy = strategy,
     )
     return out
     

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup(
   name = 'banana_dev',
   packages = ['banana_dev'],
-  version = '0.1.0',
+  version = '1.0.0',
   license='MIT',
   description = 'The banana package is a python client to interact with your machine learning models hosted on Banana',   # Give a short description about your library
   author = 'Erik Dunteman',


### PR DESCRIPTION
This adds an optional "strategy" argument to banana.run and banana.start, and points the calls to the new v2 endpoints which were created to distribute calls based on these strategy parameters.

This is a breaking change

- Results now return as a list of json rather than just json.
- I also removed the weird nuance on the return where it'd return the nested values of "output", because that was an artifact of prior backward compat and no reason to maintain it

Valid strategy looks like:
```
banana.run(
        api_key, 
        model_key, 
        model_parameters,
        strategy = {"parallelJobs": 20, "returnFirst": 10}
        )
```

I've iterated major version to 1.0.0 to indicate the breaking changes due to semantic versioning.

Tested end-to-end and passing on the proposed new backend. Will roll this and that backend in once it's tested.

