### PR TITLE
Feature/v2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/*
 .egg
 .pyc
 __pycache__
+banana_dev.egg-info
+build
+dist
 
 # testing files
 demo*

--- a/banana_dev.egg-info/PKG-INFO
+++ b/banana_dev.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: banana-dev
-Version: 0.1.0
+Version: 1.0.0
 Summary: The banana package is a python client to interact with your machine learning models hosted on Banana
 Home-page: https://www.banana.dev
 Author: Erik Dunteman

--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -18,18 +18,15 @@ if 'BANANA_URL' in os.environ:
 # ___________________________________
 
 
-def run_main(api_key, model_key, model_parameters):
-    task_id = call_start_api(api_key, model_key, model_parameters)
+def run_main(api_key, model_key, model_parameters, strategy):
+    task_id = call_start_api(api_key, model_key, model_parameters, strategy)
     # Just hardcode intervals
     while True:
         dict_out = call_check_api(api_key, task_id)
         if dict_out['data']['taskStatus'] == "Done":
-            if "output" in dict_out['data']['taskOut']:
-                return dict_out['data']['taskOut']["output"]
-            else:
-                return dict_out['data']['taskOut']
-def start_main(api_key, model_key, model_parameters):
-    task_id = call_start_api(api_key, model_key, model_parameters)
+            return dict_out['data']['taskOut']
+def start_main(api_key, model_key, model_parameters, strategy):
+    task_id = call_start_api(api_key, model_key, model_parameters, strategy)
     return task_id
 def check_main(api_key, task_id):
     dict_out = call_check_api(api_key, task_id)
@@ -40,9 +37,9 @@ def check_main(api_key, task_id):
 # ________________________
 
 # Takes in start params, returns task ID
-def call_start_api(api_key, model_key, model_parameters):
+def call_start_api(api_key, model_key, model_parameters, strategy):
     global endpoint
-    route_start = "api/task/start/v1/"
+    route_start = "api/task/start/v2/"
     url_start = endpoint + route_start
 
     payload = {
@@ -51,7 +48,8 @@ def call_start_api(api_key, model_key, model_parameters):
         "data": {
             "apiKey" : api_key,
             "modelKey" : model_key,
-            "modelParameters" : model_parameters
+            "modelParameters" : model_parameters,
+            "strategy": strategy,
         }
     }
     response = requests.post(url_start, json=payload)

--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -44,7 +44,7 @@ def call_start_api(api_key, model_key, model_parameters, strategy):
 
     payload = {
         "id": str(uuid4()),
-        "created": int(time.time()),
+        "created": time.time(),
         "data": {
             "apiKey" : api_key,
             "modelKey" : model_key,
@@ -74,7 +74,7 @@ def call_start_api(api_key, model_key, model_parameters, strategy):
 # Takes in task ID, returns reformatted dict_out with Status and Output
 def call_check_api(api_key, task_id):
     global endpoint
-    route_check = "api/task/check/v1/"
+    route_check = "api/task/check/v2/"
     url_check = endpoint + route_check
     # Poll server for completed task
 

--- a/banana_dev/package.py
+++ b/banana_dev/package.py
@@ -3,19 +3,21 @@ import asyncio
 import sys
 
 # Generics
-def run(api_key, model_key, model_parameters):
+def run(api_key, model_key, model_parameters, strategy = {}):
     out = run_main(
         api_key = api_key, 
         model_key = model_key, 
-        model_parameters = model_parameters
+        model_parameters = model_parameters,
+        strategy = strategy,
     )
     return out
 
-def start(api_key, model_key, model_parameters):
+def start(api_key, model_key, model_parameters, strategy = {}):
     out = start_main(
         api_key = api_key, 
         model_key = model_key, 
-        model_parameters = model_parameters
+        model_parameters = model_parameters,
+        strategy = strategy,
     )
     return out
     

--- a/banana_dev/package.py
+++ b/banana_dev/package.py
@@ -1,22 +1,20 @@
 from .generics import run_main, start_main, check_main
-import asyncio
-import sys
 
 # Generics
-def run(api_key, model_key, model_parameters, strategy = {}):
+def run(api_key, model_key, model_inputs, strategy = {}):
     out = run_main(
         api_key = api_key, 
         model_key = model_key, 
-        model_parameters = model_parameters,
+        model_inputs = model_inputs,
         strategy = strategy,
     )
     return out
 
-def start(api_key, model_key, model_parameters, strategy = {}):
+def start(api_key, model_key, model_inputs, strategy = {}):
     out = start_main(
         api_key = api_key, 
         model_key = model_key, 
-        model_parameters = model_parameters,
+        model_inputs = model_inputs,
         strategy = strategy,
     )
     return out

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup(
   name = 'banana_dev',
   packages = ['banana_dev'],
-  version = '0.1.0',
+  version = '1.0.0',
   license='MIT',
   description = 'The banana package is a python client to interact with your machine learning models hosted on Banana',   # Give a short description about your library
   author = 'Erik Dunteman',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setup(
   name = 'banana_dev',
   packages = ['banana_dev'],
-  version = '1.0.0',
+  version = '2.0.0',
   license='MIT',
   description = 'The banana package is a python client to interact with your machine learning models hosted on Banana',   # Give a short description about your library
   author = 'Erik Dunteman',
@@ -19,7 +19,7 @@ setup(
     "urllib3==1.26.7",
   ],
   classifiers=[
-    'Development Status :: 4 - Beta',      # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
+    'Development Status :: 5 - Production/Stable',      # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Build Tools',
     'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
# This is our first major breaking change

# Why:
- We needed to add a strategy argument, to allow batchSize parallelization across many inference servers. As part of this, we needed to be able to return a list of outputs rather than a single output, breaking backwards compatibility 
- We needed compatibility to the new "pull" style inference servers we've implemented on the backend
- Our outputs were getting pretty frankensteiny across a wide range of use cases, so we're following a standard format without any tricky client parsing logic

# Testing:
Tests pass end to end for:
- New "pull" style inference servers
- Legacy "push" style inference servers

We tried our best to make all models still work through this new sdk. The API itself is a breaking change out of necessity, but if your inference call are breaking, please contact us.